### PR TITLE
fix: restore vision listing availability and same-day kline backfill

### DIFF
--- a/src/cryptoservice/client/gateway.py
+++ b/src/cryptoservice/client/gateway.py
@@ -1,0 +1,335 @@
+"""Gateway abstractions for Binance futures async operations."""
+# ruff: noqa: D102,D107,N803
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Protocol
+
+from binance_common.errors import ForbiddenError, TooManyRequestsError
+from binance_sdk_derivatives_trading_usds_futures.rest_api import DerivativesTradingUsdsFuturesRestAPI
+from binance_sdk_derivatives_trading_usds_futures.rest_api.models.enums import (
+    KlineCandlestickDataIntervalEnum,
+    LongShortRatioPeriodEnum,
+    OpenInterestStatisticsPeriodEnum,
+    TakerBuySellVolumePeriodEnum,
+    TopTraderLongShortRatioAccountsPeriodEnum,
+    TopTraderLongShortRatioPositionsPeriodEnum,
+)
+
+
+def _to_plain(value: Any) -> Any:
+    if hasattr(value, "actual_instance"):
+        return _to_plain(value.actual_instance)
+    if hasattr(value, "to_dict"):
+        return _to_plain(value.to_dict())
+    if hasattr(value, "model_dump"):
+        return _to_plain(value.model_dump(by_alias=True, exclude_none=True))
+    if isinstance(value, list):
+        return [_to_plain(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _to_plain(item) for key, item in value.items()}
+    return value
+
+
+def _enum_value(enum_cls: type[Enum], value: str) -> Enum:
+    try:
+        return enum_cls(value)
+    except Exception as exc:
+        raise ValueError(f"Unsupported enum value '{value}' for {enum_cls.__name__}") from exc
+
+
+def _camel_metric_item(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "symbol": item.get("symbol"),
+        "fundingTime": item.get("fundingTime", item.get("funding_time")),
+        "fundingRate": item.get("fundingRate", item.get("funding_rate")),
+        "markPrice": item.get("markPrice", item.get("mark_price")),
+        "sumOpenInterest": item.get("sumOpenInterest", item.get("sum_open_interest")),
+        "sumOpenInterestValue": item.get("sumOpenInterestValue", item.get("sum_open_interest_value")),
+        "timestamp": item.get("timestamp"),
+        "longShortRatio": item.get("longShortRatio", item.get("long_short_ratio")),
+        "longAccount": item.get("longAccount", item.get("long_account")),
+        "shortAccount": item.get("shortAccount", item.get("short_account")),
+        "buySellRatio": item.get("buySellRatio", item.get("buy_sell_ratio")),
+        "buyVol": item.get("buyVol", item.get("buy_vol")),
+        "sellVol": item.get("sellVol", item.get("sell_vol")),
+    }
+
+
+def _is_rate_limit_error(error: Exception) -> bool:
+    status_code = getattr(error, "status_code", None)
+    if isinstance(status_code, int) and status_code in {418, 429}:
+        return True
+
+    error_code = getattr(error, "code", None)
+    if error_code == -1003:
+        return True
+
+    error_str = str(error).lower()
+    return any(keyword in error_str for keyword in ["too many requests", "rate limit", "429", "-1003", "418"])
+
+
+class BinanceGateway(Protocol):
+    """Async gateway interface used by service/downloader layers."""
+
+    async def futures_exchange_info(self) -> dict[str, Any]: ...
+
+    async def futures_klines(
+        self,
+        *,
+        symbol: str,
+        interval: str,
+        startTime: int | None = None,
+        endTime: int | None = None,
+        limit: int | None = None,
+    ) -> list[list[Any]]: ...
+
+    async def get_historical_klines_generator(
+        self,
+        *,
+        symbol: str,
+        interval: str,
+        start_str: str,
+        end_str: str,
+        limit: int,
+        klines_type: Any,
+    ) -> Any: ...
+
+    async def futures_funding_rate(self, **params: Any) -> list[dict[str, Any]]: ...
+
+    async def futures_open_interest_hist(self, **params: Any) -> list[dict[str, Any]]: ...
+
+    async def futures_top_longshort_account_ratio(self, **params: Any) -> list[dict[str, Any]]: ...
+
+    async def futures_top_longshort_position_ratio(self, **params: Any) -> list[dict[str, Any]]: ...
+
+    async def futures_global_longshort_ratio(self, **params: Any) -> list[dict[str, Any]]: ...
+
+    async def futures_taker_longshort_ratio(self, **params: Any) -> list[dict[str, Any]]: ...
+
+    async def close_connection(self) -> None: ...
+
+
+@dataclass(slots=True)
+class ApiErrorContext:
+    """Normalized HTTP/API error fields extracted from Binance SDK exceptions."""
+
+    status_code: int | None = None
+    code: int | None = None
+    message: str | None = None
+    reason: str | None = None
+    method: str | None = None
+    url: str | None = None
+    response_body: str | None = None
+
+
+def extract_api_error_context(error: Exception, *, max_body_length: int = 240) -> ApiErrorContext | None:
+    """Extract portable API error context from SDK exceptions when available."""
+    status_code = getattr(error, "status_code", None)
+    code = getattr(error, "code", None)
+    message = str(getattr(error, "message", "") or "") or str(getattr(error, "error_message", "") or "") or str(error)
+    response = getattr(error, "response", None)
+    reason = getattr(response, "reason", None) if response else None
+    method = getattr(response, "method", None) if response else None
+    url = getattr(response, "url", None) if response else None
+
+    if status_code is None and isinstance(error, ForbiddenError):
+        status_code = 403
+    if status_code is None and isinstance(error, TooManyRequestsError):
+        status_code = 429
+
+    response_body = None
+    body = getattr(response, "_body", None) if response else None
+    if isinstance(body, bytes | bytearray):
+        response_body = body.decode("utf-8", errors="replace")
+    elif isinstance(body, str):
+        response_body = body
+    if response_body:
+        normalized = " ".join(response_body.split())
+        response_body = normalized[:max_body_length] + ("..." if len(normalized) > max_body_length else "") if normalized else None
+
+    if any(value is not None for value in (status_code, code, message, reason, method, url, response_body)):
+        return ApiErrorContext(
+            status_code=status_code if isinstance(status_code, int) else None,
+            code=code if isinstance(code, int) else None,
+            message=message,
+            reason=reason,
+            method=method,
+            url=url,
+            response_body=response_body,
+        )
+    return None
+
+
+class OfficialBinanceGateway:
+    """Official USDs Futures gateway adapter."""
+
+    def __init__(self, futures_rest_client: DerivativesTradingUsdsFuturesRestAPI) -> None:
+        self._futures = futures_rest_client
+
+    async def _call(self, fn, *args, **kwargs) -> Any:
+        response = await asyncio.to_thread(fn, *args, **kwargs)
+        return _to_plain(response.data())
+
+    async def futures_exchange_info(self) -> dict[str, Any]:
+        data = await self._call(self._futures.exchange_information)
+        return data if isinstance(data, dict) else {}
+
+    async def futures_klines(
+        self,
+        *,
+        symbol: str,
+        interval: str,
+        startTime: int | None = None,
+        endTime: int | None = None,
+        limit: int | None = None,
+    ) -> list[list[Any]]:
+        enum_interval = _enum_value(KlineCandlestickDataIntervalEnum, interval)
+        data = await self._call(
+            self._futures.kline_candlestick_data,
+            symbol=symbol,
+            interval=enum_interval,
+            start_time=startTime,
+            end_time=endTime,
+            limit=limit,
+        )
+        return data if isinstance(data, list) else []
+
+    async def get_historical_klines_generator(  # noqa: C901
+        self,
+        *,
+        symbol: str,
+        interval: str,
+        start_str: str,
+        end_str: str,
+        limit: int,
+        klines_type: Any,
+    ) -> Any:
+        del klines_type
+        cursor = int(start_str)
+        end_ts = int(end_str)
+        page_limit = max(1, min(limit, 1500))
+        max_rate_limit_retries = 5
+
+        while cursor < end_ts:
+            retry_count = 0
+            while True:
+                try:
+                    rows = await self.futures_klines(
+                        symbol=symbol,
+                        interval=interval,
+                        startTime=cursor,
+                        endTime=end_ts,
+                        limit=page_limit,
+                    )
+                    break
+                except Exception as exc:
+                    if not _is_rate_limit_error(exc) or retry_count >= max_rate_limit_retries:
+                        raise
+                    retry_delay = min(0.25 * (2**retry_count), 2.0)
+                    retry_count += 1
+                    await asyncio.sleep(retry_delay)
+
+            if not rows:
+                break
+
+            last_open_time = cursor
+            for row in rows:
+                yield row
+                if isinstance(row, list) and row:
+                    try:
+                        last_open_time = int(row[0])
+                    except (TypeError, ValueError, IndexError):
+                        continue
+
+            if len(rows) < page_limit:
+                break
+            if last_open_time < cursor:
+                break
+            cursor = last_open_time + 1
+
+    async def futures_funding_rate(self, **params: Any) -> list[dict[str, Any]]:
+        data = await self._call(
+            self._futures.get_funding_rate_history,
+            symbol=params.get("symbol"),
+            start_time=params.get("startTime"),
+            end_time=params.get("endTime"),
+            limit=params.get("limit"),
+        )
+        return [_camel_metric_item(item) for item in data] if isinstance(data, list) else []
+
+    async def futures_open_interest_hist(self, **params: Any) -> list[dict[str, Any]]:
+        data = await self._call(
+            self._futures.open_interest_statistics,
+            symbol=params.get("symbol"),
+            period=_enum_value(OpenInterestStatisticsPeriodEnum, params.get("period", "5m")),
+            limit=params.get("limit"),
+            start_time=params.get("startTime"),
+            end_time=params.get("endTime"),
+        )
+        return [_camel_metric_item(item) for item in data] if isinstance(data, list) else []
+
+    async def futures_top_longshort_account_ratio(self, **params: Any) -> list[dict[str, Any]]:
+        data = await self._call(
+            self._futures.top_trader_long_short_ratio_accounts,
+            symbol=params.get("symbol"),
+            period=_enum_value(TopTraderLongShortRatioAccountsPeriodEnum, params.get("period", "5m")),
+            limit=params.get("limit"),
+            start_time=params.get("startTime"),
+            end_time=params.get("endTime"),
+        )
+        return [_camel_metric_item(item) for item in data] if isinstance(data, list) else []
+
+    async def futures_top_longshort_position_ratio(self, **params: Any) -> list[dict[str, Any]]:
+        data = await self._call(
+            self._futures.top_trader_long_short_ratio_positions,
+            symbol=params.get("symbol"),
+            period=_enum_value(TopTraderLongShortRatioPositionsPeriodEnum, params.get("period", "5m")),
+            limit=params.get("limit"),
+            start_time=params.get("startTime"),
+            end_time=params.get("endTime"),
+        )
+        return [_camel_metric_item(item) for item in data] if isinstance(data, list) else []
+
+    async def futures_global_longshort_ratio(self, **params: Any) -> list[dict[str, Any]]:
+        data = await self._call(
+            self._futures.long_short_ratio,
+            symbol=params.get("symbol"),
+            period=_enum_value(LongShortRatioPeriodEnum, params.get("period", "5m")),
+            limit=params.get("limit"),
+            start_time=params.get("startTime"),
+            end_time=params.get("endTime"),
+        )
+        return [_camel_metric_item(item) for item in data] if isinstance(data, list) else []
+
+    async def futures_taker_longshort_ratio(self, **params: Any) -> list[dict[str, Any]]:
+        symbol = params.get("symbol")
+        data = await self._call(
+            self._futures.taker_buy_sell_volume,
+            symbol=symbol,
+            period=_enum_value(TakerBuySellVolumePeriodEnum, params.get("period", "5m")),
+            limit=params.get("limit"),
+            start_time=params.get("startTime"),
+            end_time=params.get("endTime"),
+        )
+        if not isinstance(data, list):
+            return []
+
+        normalized: list[dict[str, Any]] = []
+        for item in data:
+            camel = _camel_metric_item(item)
+            if symbol and not camel.get("symbol"):
+                camel["symbol"] = symbol
+            camel["longShortRatio"] = camel.get("longShortRatio") or camel.get("buySellRatio")
+            camel["longAccount"] = camel.get("longAccount") or camel.get("buyVol")
+            camel["shortAccount"] = camel.get("shortAccount") or camel.get("sellVol")
+            normalized.append(camel)
+        return normalized
+
+    async def close_connection(self) -> None:
+        session = getattr(self._futures, "_session", None)
+        if session is not None and hasattr(session, "close"):
+            await asyncio.to_thread(session.close)

--- a/src/cryptoservice/services/downloaders/kline_downloader.py
+++ b/src/cryptoservice/services/downloaders/kline_downloader.py
@@ -4,13 +4,18 @@
 """
 
 import asyncio
+import csv
 import time
 from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+from io import BytesIO
 from pathlib import Path
 from typing import Any
+from zipfile import BadZipFile, ZipFile
 
-from binance import AsyncClient
+import aiohttp
 
+from cryptoservice.client import BinanceGateway
 from cryptoservice.config import RetryConfig
 from cryptoservice.config.logging import get_logger
 from cryptoservice.exceptions import InvalidSymbolError, MarketDataFetchError, RateLimitError
@@ -33,7 +38,7 @@ class KlineDownloader(BaseDownloader):
 
     def __init__(
         self,
-        client: AsyncClient,
+        client: BinanceGateway,
         request_delay: float = 0.5,
         endpoint_controls: EndpointControlRegistry | None = None,
     ):
@@ -48,7 +53,7 @@ class KlineDownloader(BaseDownloader):
         self.db: AsyncMarketDB | None = None
         self._run_id: str | None = None
 
-    async def download_single_symbol(
+    async def download_single_symbol(  # noqa: C901
         self,
         symbol: str,
         start_ts: str,
@@ -60,6 +65,7 @@ class KlineDownloader(BaseDownloader):
     ) -> AsyncGenerator[PerpetualMarketTicker, None]:
         """异步下载单个交易对的K线数据, 并以生成器模式返回."""
         try:
+            del klines_type
             logger.debug(
                 "download.range_start",
                 run=self._run_id,
@@ -70,40 +76,47 @@ class KlineDownloader(BaseDownloader):
                 interval=interval.value,
             )
 
-            async def request_func():
-                return await self.client.get_historical_klines_generator(
-                    symbol=symbol,
-                    interval=interval.value,
-                    start_str=start_ts,
-                    end_str=end_ts,
-                    limit=1500,
-                    klines_type=HistoricalKlinesType.to_binance(klines_type),
-                )
-
-            klines_generator = await self._handle_async_request_with_retry(
-                request_func,
-                retry_config=retry_config,
-                endpoint_key="fapi_klines",
-                endpoint_max_workers=endpoint_max_workers,
-            )
-
-            if not klines_generator:
-                logger.debug(
-                    "download.range_empty",
-                    run=self._run_id,
-                    dataset="kline",
-                    symbol=symbol,
-                    start_ts=start_ts,
-                    end_ts=end_ts,
-                )
-                return
-
+            cursor = int(start_ts)
+            end_time = int(end_ts)
+            page_limit = 1500
             processed_count = 0
-            async for kline in klines_generator:
-                validated_kline = self._validate_single_kline(kline, symbol)
-                if validated_kline:
-                    yield PerpetualMarketTicker.from_binance_kline(symbol=symbol, kline=validated_kline)
-                    processed_count += 1
+            while cursor < end_time:
+                current_cursor = cursor
+
+                async def request_func(start_cursor: int = current_cursor):
+                    return await self.client.futures_klines(
+                        symbol=symbol,
+                        interval=interval.value,
+                        startTime=start_cursor,
+                        endTime=end_time,
+                        limit=page_limit,
+                    )
+
+                klines = await self._handle_async_request_with_retry(
+                    request_func,
+                    retry_config=retry_config,
+                    endpoint_key="fapi_klines",
+                    endpoint_max_workers=endpoint_max_workers,
+                )
+                if not klines:
+                    break
+
+                last_open_time = cursor
+                for kline in klines:
+                    validated_kline = self._validate_single_kline(kline, symbol)
+                    if validated_kline:
+                        yield PerpetualMarketTicker.from_binance_kline(symbol=symbol, kline=validated_kline)
+                        processed_count += 1
+                        try:
+                            last_open_time = int(validated_kline[0])
+                        except (ValueError, TypeError, IndexError):
+                            continue
+
+                if len(klines) < page_limit:
+                    break
+                if last_open_time < cursor:
+                    break
+                cursor = last_open_time + 1
 
             logger.debug(
                 "download.range_done",
@@ -157,8 +170,16 @@ class KlineDownloader(BaseDownloader):
         retry_config: RetryConfig | None = None,
         incremental: bool = True,
         run_id: str | None = None,
+        precomputed_ranges: dict[str, list[tuple[str, str]]] | None = None,
+        source: str = "api",
     ) -> IntegrityReport:
-        """批量异步下载多个交易对的K线数据."""
+        """批量异步下载多个交易对的K线数据.
+
+        When *precomputed_ranges* is provided the internal incremental
+        planning step is skipped entirely and the supplied ranges are
+        used directly.  This enables the global ``plan_universe_download``
+        optimisation where planning runs once across all days.
+        """
         run = run_id or generate_run_id("kline")
         self._run_id = run
         self.begin_run_state(run_id=run, stage="kline", dataset="kline")
@@ -170,7 +191,37 @@ class KlineDownloader(BaseDownloader):
 
         plan_ranges: dict[str, list[tuple[str, str]]] = {}
 
-        if incremental:
+        if precomputed_ranges is not None:
+            plan_ranges = precomputed_ranges
+            symbols = list(precomputed_ranges.keys())
+            if not symbols:
+                elapsed_ms = int((time.perf_counter() - started_at) * 1000)
+                logger.info(
+                    "download.stage_done",
+                    run=run,
+                    stage="kline",
+                    dataset="kline",
+                    status="skipped",
+                    duration_ms=elapsed_ms,
+                    symbols=0,
+                    interval=interval.value,
+                    reason="already_up_to_date",
+                )
+                return IntegrityReport(
+                    total_symbols=0,
+                    successful_symbols=0,
+                    failed_symbols=[],
+                    missing_periods=[],
+                    data_quality_score=1.0,
+                    recommendations=["所有数据已是最新状态"],
+                )
+            logger.debug(
+                "download.plan_precomputed",
+                run=run,
+                dataset="kline",
+                selected=len(symbols),
+            )
+        elif incremental:
             logger.debug(
                 "download.incremental_start",
                 run=run,
@@ -279,6 +330,22 @@ class KlineDownloader(BaseDownloader):
             incremental=incremental,
         )
 
+        vision_session: aiohttp.ClientSession | None = None
+        if source == "vision":
+            vision_session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=60, connect=10),
+                trust_env=True,
+            )
+
+        def _extract_missing_periods(outcome: dict[str, Any]) -> list[dict[str, Any]]:
+            missing_items = outcome.get("missing_periods")
+            if isinstance(missing_items, list):
+                return [item for item in missing_items if isinstance(item, dict)]
+            single_missing = outcome.get("missing")
+            if isinstance(single_missing, dict):
+                return [single_missing]
+            return []
+
         async def worker() -> None:
             while True:
                 symbol = await task_queue.get()
@@ -292,14 +359,17 @@ class KlineDownloader(BaseDownloader):
                         interval=interval,
                         retry_config=retry_config,
                         endpoint_max_workers=max_workers,
+                        source=source,
+                        vision_session=vision_session,
                     )
                     async with results_lock:
                         status = outcome["status"]
-                        if status == "success":
+                        if status in {"success", "partial"}:
                             successful_symbols.append(symbol)
+                            missing_periods.extend(_extract_missing_periods(outcome))
                         elif status in {"empty", "failed"}:
                             failed_symbols.append(symbol)
-                            missing_periods.append(outcome["missing"])
+                            missing_periods.extend(_extract_missing_periods(outcome))
                 finally:
                     task_queue.task_done()
 
@@ -309,6 +379,9 @@ class KlineDownloader(BaseDownloader):
                     tg.create_task(worker())
         except* RateLimitError as grouped_rate_limit:
             raise grouped_rate_limit.exceptions[0] from None
+        finally:
+            if vision_session is not None and not vision_session.closed:
+                await vision_session.close()
 
         elapsed_ms = int((time.perf_counter() - started_at) * 1000)
         logger.info(
@@ -341,9 +414,19 @@ class KlineDownloader(BaseDownloader):
         interval: Freq,
         retry_config: RetryConfig | None,
         endpoint_max_workers: int,
+        source: str = "api",
+        vision_session: aiohttp.ClientSession | None = None,
     ) -> dict[str, Any]:
         """下载并存储单个交易对数据，返回结果摘要."""
         try:
+            if source == "vision":
+                return await self._process_symbol_from_vision(
+                    symbol=symbol,
+                    download_ranges=download_ranges,
+                    interval=interval,
+                    vision_session=vision_session,
+                )
+
             total_processed = 0
 
             for range_start, range_end in download_ranges:
@@ -424,6 +507,176 @@ class KlineDownloader(BaseDownloader):
                 "reason": str(exc),
             }
             return {"status": "failed", "missing": missing}
+
+    async def _process_symbol_from_vision(  # noqa: C901
+        self,
+        *,
+        symbol: str,
+        download_ranges: list[tuple[str, str]],
+        interval: Freq,
+        vision_session: aiohttp.ClientSession | None,
+    ) -> dict[str, Any]:
+        if vision_session is None:
+            raise MarketDataFetchError("Vision session is not initialized")
+
+        total_processed = 0
+        day_missing: list[dict[str, Any]] = []
+        target_dates = self._expand_ranges_to_dates(download_ranges)
+
+        for date_str in target_dates:
+            rows, reason = await self._download_vision_kline_rows(
+                session=vision_session,
+                symbol=symbol,
+                interval=interval,
+                date_str=date_str,
+            )
+            if rows is None:
+                day_missing.append({"symbol": symbol, "date": date_str, "period": f"{date_str} - {date_str}", "reason": reason})
+                continue
+
+            if not self._is_full_day_kline(rows, date_str=date_str, interval=interval):
+                day_missing.append(
+                    {
+                        "symbol": symbol,
+                        "date": date_str,
+                        "period": f"{date_str} - {date_str}",
+                        "reason": "vision_not_full_day",
+                    }
+                )
+                continue
+
+            chunk: list[PerpetualMarketTicker] = []
+            inserted = 0
+            try:
+                for row in rows:
+                    chunk.append(PerpetualMarketTicker.from_binance_kline(symbol=symbol, kline=row))
+                    if len(chunk) >= 1000:
+                        if self.db:
+                            await self.db.insert_klines(chunk, interval)
+                        inserted += len(chunk)
+                        chunk = []
+                if chunk and self.db:
+                    await self.db.insert_klines(chunk, interval)
+                    inserted += len(chunk)
+            except Exception:
+                day_missing.append(
+                    {
+                        "symbol": symbol,
+                        "date": date_str,
+                        "period": f"{date_str} - {date_str}",
+                        "reason": "vision_not_full_day",
+                    }
+                )
+                continue
+
+            total_processed += inserted
+
+        if total_processed > 0 and day_missing:
+            return {"status": "partial", "rows": total_processed, "missing_periods": day_missing}
+        if total_processed > 0:
+            return {"status": "success", "rows": total_processed, "missing_periods": []}
+        if day_missing:
+            return {"status": "failed", "missing_periods": day_missing}
+
+        overall_start = download_ranges[0][0]
+        overall_end = download_ranges[-1][1]
+        return {
+            "status": "empty",
+            "missing_periods": [
+                {
+                    "symbol": symbol,
+                    "period": (f"{self._format_timestamp(overall_start)} - {self._format_timestamp(overall_end)}"),
+                    "reason": "no_data",
+                }
+            ],
+        }
+
+    async def _download_vision_kline_rows(
+        self,
+        *,
+        session: aiohttp.ClientSession,
+        symbol: str,
+        interval: Freq,
+        date_str: str,
+    ) -> tuple[list[list[Any]] | None, str]:
+        interval_value = interval.value
+        base_url = "https://data.binance.vision/data/futures/um/daily/klines"
+        file_name = f"{symbol}-{interval_value}-{date_str}.zip"
+        url = f"{base_url}/{symbol}/{interval_value}/{file_name}"
+
+        try:
+            async with session.get(url) as response:
+                if response.status == 404:
+                    return None, "vision_file_missing"
+                response.raise_for_status()
+                payload = await response.read()
+        except aiohttp.ClientResponseError as exc:
+            if exc.status == 404:
+                return None, "vision_file_missing"
+            return None, "vision_download_error"
+        except Exception:
+            return None, "vision_download_error"
+
+        try:
+            with ZipFile(BytesIO(payload)) as zip_file:
+                csv_files = [name for name in zip_file.namelist() if name.endswith(".csv")]
+                if not csv_files:
+                    return None, "vision_not_full_day"
+                with zip_file.open(csv_files[0]) as fp:
+                    text_rows = fp.read().decode("utf-8").splitlines()
+            rows = [row for row in csv.reader(text_rows) if row]
+            return rows, ""
+        except (BadZipFile, OSError, UnicodeDecodeError, ValueError):
+            return None, "vision_not_full_day"
+
+    @staticmethod
+    def _expand_ranges_to_dates(download_ranges: list[tuple[str, str]]) -> list[str]:
+        dates: set[str] = set()
+        for range_start, range_end in download_ranges:
+            start_ms = int(range_start)
+            end_ms = int(range_end)
+            start_dt = datetime.fromtimestamp(start_ms / 1000, tz=UTC).date()
+            end_inclusive = start_dt if end_ms <= start_ms else datetime.fromtimestamp((end_ms - 1) / 1000, tz=UTC).date()
+
+            current = start_dt
+            while current <= end_inclusive:
+                dates.add(current.strftime("%Y-%m-%d"))
+                current += timedelta(days=1)
+        return sorted(dates)
+
+    @staticmethod
+    def _interval_to_milliseconds(interval: Freq) -> int:
+        mapping = {
+            Freq.m1: 60_000,
+            Freq.m3: 180_000,
+            Freq.m5: 300_000,
+            Freq.m15: 900_000,
+            Freq.m30: 1_800_000,
+            Freq.h1: 3_600_000,
+            Freq.h2: 7_200_000,
+            Freq.h4: 14_400_000,
+            Freq.h6: 21_600_000,
+            Freq.h8: 28_800_000,
+            Freq.h12: 43_200_000,
+            Freq.d1: 86_400_000,
+        }
+        return mapping[interval]
+
+    def _is_full_day_kline(self, rows: list[list[Any]], *, date_str: str, interval: Freq) -> bool:
+        step_ms = self._interval_to_milliseconds(interval)
+        expected_points = 86_400_000 // step_ms
+        if len(rows) != expected_points:
+            return False
+
+        day_start = int(datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=UTC).timestamp() * 1000)
+        expected_last = day_start + (expected_points - 1) * step_ms
+        try:
+            open_times = [int(row[0]) for row in rows]
+        except (TypeError, ValueError, IndexError):
+            return False
+        if open_times[0] != day_start or open_times[-1] != expected_last:
+            return False
+        return all(ts == day_start + idx * step_ms for idx, ts in enumerate(open_times))
 
     def _validate_single_kline(self, kline: list, symbol: str) -> list | None:
         """验证单条K线数据质量."""

--- a/src/cryptoservice/services/market_service.py
+++ b/src/cryptoservice/services/market_service.py
@@ -10,18 +10,17 @@ import json
 import re
 import time
 from collections import defaultdict
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, TypedDict, cast
 
-from binance import AsyncClient
+import aiohttp
 
-from cryptoservice.client import BinanceClientFactory
-from cryptoservice.config import RetryConfig, settings
+from cryptoservice.client import BinanceClientFactory, BinanceGateway
+from cryptoservice.config import RetryConfig
 from cryptoservice.config.logging import get_logger
-from cryptoservice.exceptions import InvalidSymbolError, MarketDataFetchError, RateLimitError
+from cryptoservice.exceptions import MarketDataFetchError, RateLimitError
 from cryptoservice.models import (
-    DailyMarketTicker,
     Freq,
     FundingRate,
     FuturesKlineTicker,
@@ -29,13 +28,14 @@ from cryptoservice.models import (
     IntegrityReport,
     LongShortRatio,
     OpenInterest,
-    SortBy,
-    SpotKlineTicker,
-    SymbolTicker,
     UniverseDefinition,
 )
 from cryptoservice.models.universe import MISSING_REASON_MISSING_IN_EXPORT, UniverseDailySnapshot
 from cryptoservice.storage.database import Database
+from cryptoservice.storage.incremental import (
+    UniverseDownloadPlan,
+    gather_symbol_date_ranges,
+)
 from cryptoservice.utils import DataConverter
 from cryptoservice.utils.run_id import generate_run_id
 
@@ -45,12 +45,86 @@ from .processors import CategoryManager, DataValidator, UniverseManager
 logger = get_logger(__name__)
 SYMBOL_CHECK_TIMEOUT_SECONDS = 20.0
 _SYMBOL_CHECK_ENDPOINT = "fapi_symbol_check_1m"
+_EXCHANGE_INFO_ENDPOINT = "fapi_exchange_info"
+_MINUTE_MS = 60_000
+_DAY_MS = 24 * 60 * 60 * 1000
+_ASOF_LOOKBACK_DAYS = {
+    "funding_rate": 3,
+    "open_interest": 1,
+    "long_short_ratio": 1,
+}
+_LSR_RATIO_TYPES = ("account", "position", "global", "taker")
+
+
+class _DayScanStats(TypedDict):
+    count: int
+    first: int | None
+    last: int | None
+    prev: int | None
+    broken: bool
+
+
+class _PublicNoopGateway:
+    """No-op gateway used for public define workflows."""
+
+    async def futures_exchange_info(self) -> dict[str, Any]:
+        raise MarketDataFetchError("Gateway unavailable in public define mode")
+
+    async def futures_klines(
+        self,
+        *,
+        symbol: str,
+        interval: str,
+        **kwargs: Any,
+    ) -> list[list[Any]]:
+        del symbol, interval, kwargs
+        raise MarketDataFetchError("Gateway unavailable in public define mode")
+
+    async def get_historical_klines_generator(
+        self,
+        *,
+        symbol: str,
+        interval: str,
+        start_str: str,
+        end_str: str,
+        limit: int,
+        klines_type: Any,
+    ) -> Any:
+        del symbol, interval, start_str, end_str, limit, klines_type
+        raise MarketDataFetchError("Gateway unavailable in public define mode")
+
+    async def futures_funding_rate(self, **params: Any) -> list[dict[str, Any]]:
+        del params
+        raise MarketDataFetchError("Gateway unavailable in public define mode")
+
+    async def futures_open_interest_hist(self, **params: Any) -> list[dict[str, Any]]:
+        del params
+        raise MarketDataFetchError("Gateway unavailable in public define mode")
+
+    async def futures_top_longshort_account_ratio(self, **params: Any) -> list[dict[str, Any]]:
+        del params
+        raise MarketDataFetchError("Gateway unavailable in public define mode")
+
+    async def futures_top_longshort_position_ratio(self, **params: Any) -> list[dict[str, Any]]:
+        del params
+        raise MarketDataFetchError("Gateway unavailable in public define mode")
+
+    async def futures_global_longshort_ratio(self, **params: Any) -> list[dict[str, Any]]:
+        del params
+        raise MarketDataFetchError("Gateway unavailable in public define mode")
+
+    async def futures_taker_longshort_ratio(self, **params: Any) -> list[dict[str, Any]]:
+        del params
+        raise MarketDataFetchError("Gateway unavailable in public define mode")
+
+    async def close_connection(self) -> None:
+        return None
 
 
 class MarketDataService:
     """市场数据服务实现类."""
 
-    def __init__(self, client: AsyncClient) -> None:
+    def __init__(self, client: BinanceGateway) -> None:
         """初始化市场数据服务 (私有构造函数)."""
         self.client = client
         self.converter = DataConverter()
@@ -67,8 +141,13 @@ class MarketDataService:
     @classmethod
     async def create(cls, api_key: str, api_secret: str) -> MarketDataService:
         """异步创建MarketDataService实例."""
-        client = await BinanceClientFactory.create_async_client(api_key, api_secret)
+        client = await BinanceClientFactory.create_gateway(api_key, api_secret)
         return cls(client)
+
+    @classmethod
+    async def create_public(cls) -> MarketDataService:
+        """Create service for public define workflows without API credentials."""
+        return cls(cast(BinanceGateway, _PublicNoopGateway()))
 
     async def __aenter__(self) -> MarketDataService:
         """异步上下文管理器入口."""
@@ -82,29 +161,22 @@ class MarketDataService:
 
     # ==================== 基础市场数据API ====================
 
-    async def get_symbol_ticker(self, symbol: str | None = None) -> SymbolTicker | list[SymbolTicker]:
-        """获取单个或所有交易对的行情数据."""
-        try:
-            ticker = await self.client.get_symbol_ticker(symbol=symbol)
-            if not ticker:
-                raise InvalidSymbolError(f"Invalid symbol: {symbol}")
-
-            if isinstance(ticker, list):
-                return [SymbolTicker.from_binance_ticker(t) for t in ticker]
-            return SymbolTicker.from_binance_ticker(ticker)
-
-        except Exception as e:
-            logger.error(f"Error fetching ticker for {symbol}: {e}")
-            raise MarketDataFetchError(f"Failed to fetch ticker: {e}") from e
-
     async def get_perpetual_symbols(self, only_trading: bool = True, quote_asset: str = "USDT") -> list[str]:
         """获取当前市场上所有永续合约交易对."""
         try:
             logger.debug("fetch_perpetual_symbols", quote_asset=quote_asset, only_trading=only_trading)
-            futures_info = await self.client.futures_exchange_info()
+
+            async def request_func():
+                return await self.client.futures_exchange_info()
+
+            futures_info = await self.kline_downloader._handle_async_request_with_retry(
+                request_func,
+                endpoint_key=_EXCHANGE_INFO_ENDPOINT,
+            )
+            symbols = futures_info.get("symbols", []) if isinstance(futures_info, dict) else []
             perpetual_symbols = [
                 symbol["symbol"]
-                for symbol in futures_info["symbols"]
+                for symbol in symbols
                 if symbol["contractType"] == "PERPETUAL" and (not only_trading or symbol["status"] == "TRADING") and symbol["symbol"].endswith(quote_asset)
             ]
 
@@ -115,42 +187,96 @@ class MarketDataService:
             logger.error(f"Failed to fetch perpetual symbols: {e}")
             raise MarketDataFetchError(f"Failed to fetch perpetual symbols: {e}") from e
 
-    async def get_top_coins(
+    async def _get_vision_kline_available_dates(
         self,
-        limit: int = settings.DEFAULT_LIMIT,
-        sort_by: SortBy = SortBy.QUOTE_VOLUME,
-        quote_asset: str | None = None,
-    ) -> list[DailyMarketTicker]:
-        """获取前 N 个交易对."""
+        *,
+        symbol: str,
+        start_date: str,
+        end_date: str,
+        interval: str = "1m",
+    ) -> set[str]:
+        """List available Vision daily kline files for one symbol and date range."""
+        normalized_symbol = symbol.strip().upper()
+        normalized_interval = interval.strip()
+        if not normalized_symbol:
+            raise ValueError("symbol cannot be empty")
+        if not normalized_interval:
+            raise ValueError("interval cannot be empty")
+
+        prefix = f"data/futures/um/daily/klines/{normalized_symbol}/{normalized_interval}/"
+        listing_url = "https://s3.ap-northeast-1.amazonaws.com/data.binance.vision/"
+        timeout = aiohttp.ClientTimeout(total=30, connect=10)
+        filename_pattern = re.compile(rf"{re.escape(normalized_symbol)}-{re.escape(normalized_interval)}-(\d{{4}}-\d{{2}}-\d{{2}})\.zip")
+        key_pattern = re.compile(r"<Key>([^<]+)</Key>")
+        truncated_pattern = re.compile(r"<IsTruncated>(true|false)</IsTruncated>", re.IGNORECASE)
+        token_pattern = re.compile(r"<NextContinuationToken>([^<]+)</NextContinuationToken>")
+
         try:
-            tickers = await self.client.get_ticker()
-            market_tickers = [DailyMarketTicker.from_binance_ticker(t) for t in tickers]
+            available_dates: set[str] = set()
+            continuation_token: str | None = None
 
-            if quote_asset:
-                market_tickers = [t for t in market_tickers if t.symbol.endswith(quote_asset)]
+            async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
+                while True:
+                    params = {
+                        "list-type": "2",
+                        "prefix": prefix,
+                        "max-keys": "1000",
+                    }
+                    if continuation_token:
+                        params["continuation-token"] = continuation_token
 
-            return sorted(
-                market_tickers,
-                key=lambda x: getattr(x, sort_by.value),
-                reverse=True,
-            )[:limit]
+                    async with session.get(listing_url, params=params) as response:
+                        response.raise_for_status()
+                        payload = await response.text()
 
-        except Exception as e:
-            logger.error(f"Error getting top coins: {e}")
-            raise MarketDataFetchError(f"Failed to get top coins: {e}") from e
+                    page_dates, is_truncated, next_token = self._parse_vision_listing_page(
+                        payload=payload,
+                        filename_pattern=filename_pattern,
+                        key_pattern=key_pattern,
+                        truncated_pattern=truncated_pattern,
+                        token_pattern=token_pattern,
+                        start_date=start_date,
+                        end_date=end_date,
+                    )
+                    available_dates.update(page_dates)
 
-    async def get_market_summary(self, interval: Freq = Freq.d1) -> dict[str, Any]:
-        """获取市场概览."""
-        try:
-            summary: dict[str, Any] = {"snapshot_time": datetime.now(), "data": {}}
-            tickers_result = await self.get_symbol_ticker()
-            tickers = [ticker.to_dict() for ticker in tickers_result] if isinstance(tickers_result, list) else [tickers_result.to_dict()]
-            summary["data"] = tickers
-            return summary
+                    if not is_truncated:
+                        break
+                    if not next_token:
+                        raise RuntimeError("Vision listing response marked truncated but omitted continuation token")
+                    continuation_token = next_token
+        except Exception as exc:
+            raise MarketDataFetchError(f"Failed to list Vision kline files for {normalized_symbol} [{start_date}~{end_date}]: {exc}") from exc
 
-        except Exception as e:
-            logger.error(f"Error getting market summary: {e}")
-            raise MarketDataFetchError(f"Failed to get market summary: {e}") from e
+        return available_dates
+
+    @staticmethod
+    def _parse_vision_listing_page(
+        *,
+        payload: str,
+        filename_pattern: re.Pattern[str],
+        key_pattern: re.Pattern[str],
+        truncated_pattern: re.Pattern[str],
+        token_pattern: re.Pattern[str],
+        start_date: str,
+        end_date: str,
+    ) -> tuple[set[str], bool, str]:
+        page_dates: set[str] = set()
+        for key in key_pattern.findall(payload):
+            if not key.endswith(".zip"):
+                continue
+            match = filename_pattern.search(key)
+            if match is None:
+                continue
+            date_str = match.group(1)
+            if start_date <= date_str <= end_date:
+                page_dates.add(date_str)
+
+        is_truncated_match = truncated_pattern.search(payload)
+        is_truncated = bool(is_truncated_match and is_truncated_match.group(1).strip().lower() == "true")
+        token_match = token_pattern.search(payload)
+        next_token = token_match.group(1).strip() if token_match else ""
+        return page_dates, is_truncated, next_token
 
     async def get_historical_klines(
         self,
@@ -158,9 +284,8 @@ class MarketDataService:
         start_time: str | datetime,
         interval: Freq,
         end_time: str | datetime | None = None,
-        klines_type: HistoricalKlinesType = HistoricalKlinesType.SPOT,
-    ) -> list[SpotKlineTicker] | list[FuturesKlineTicker]:
-        """获取历史行情数据."""
+    ) -> list[FuturesKlineTicker]:
+        """获取期货历史行情数据."""
         try:
             if isinstance(start_time, str):
                 start_time = datetime.fromisoformat(start_time)
@@ -169,37 +294,23 @@ class MarketDataService:
             elif isinstance(end_time, str):
                 end_time = datetime.fromisoformat(end_time)
 
-            start_ts = self._date_to_timestamp_start(start_time.strftime("%Y-%m-%d"))
-            end_ts = self._date_to_timestamp_end(end_time.strftime("%Y-%m-%d"))
+            start_ts = int(self._date_to_timestamp_start(start_time.strftime("%Y-%m-%d")))
+            end_ts = int(self._date_to_timestamp_end(end_time.strftime("%Y-%m-%d")))
 
-            market_type = "期货" if klines_type == HistoricalKlinesType.FUTURES else "现货"
-            logger.debug("fetch_historical_klines", symbol=symbol, market_type=market_type, interval=interval.value)
-
-            ticker_class: type[SpotKlineTicker] | type[FuturesKlineTicker]
-            if klines_type == HistoricalKlinesType.FUTURES:
-                klines = await self.client.futures_klines(
-                    symbol=symbol,
-                    interval=interval.value,
-                    startTime=start_ts,
-                    endTime=end_ts,
-                    limit=1500,
-                )
-                ticker_class = FuturesKlineTicker
-            else:
-                klines = await self.client.get_klines(
-                    symbol=symbol,
-                    interval=interval.value,
-                    startTime=start_ts,
-                    endTime=end_ts,
-                    limit=1500,
-                )
-                ticker_class = SpotKlineTicker
+            logger.debug("fetch_historical_klines", symbol=symbol, market_type="期货", interval=interval.value)
+            klines = await self.client.futures_klines(
+                symbol=symbol,
+                interval=interval.value,
+                startTime=start_ts,
+                endTime=end_ts,
+                limit=1500,
+            )
 
             data = list(klines)
             if not data:
                 logger.warning(f"No data found for symbol {symbol} in the requested time range")
-            result = [ticker_class.from_binance_kline(symbol, kline) for kline in data]
-            return cast(list[FuturesKlineTicker] | list[SpotKlineTicker], result)
+            result = [FuturesKlineTicker.from_binance_kline(symbol, kline) for kline in data]
+            return cast(list[FuturesKlineTicker], result)
 
         except Exception as e:
             logger.error(f"Error getting historical data for {symbol}: {e}")
@@ -306,6 +417,7 @@ class MarketDataService:
         interval: Freq = Freq.m1,
         max_api_workers: int = 1,
         max_vision_workers: int = 50,
+        max_day_workers: int = 3,
         max_retries: int = 3,
         start_date: str | None = None,
         end_date: str | None = None,
@@ -339,6 +451,7 @@ class MarketDataService:
                 max_api_workers=max_api_workers,
                 max_vision_workers=max_vision_workers,
                 max_retries=max_retries,
+                max_day_workers=max_day_workers,
                 run_id=run_id,
                 universe_file=str(universe_file_obj),
                 snapshots=filtered_snapshots,
@@ -389,6 +502,7 @@ class MarketDataService:
         max_api_workers: int,
         max_vision_workers: int,
         max_retries: int,
+        max_day_workers: int = 3,
         run_id: str | None = None,
         universe_file: str | None = None,
         snapshots: list[UniverseDailySnapshot] | None = None,
@@ -398,7 +512,12 @@ class MarketDataService:
         override_start_date: str | None = None,
         override_end_date: str | None = None,
     ) -> dict[str, Any]:
-        """Execute strict day-symbol download plan from universe daily snapshots."""
+        """Execute universe download with global plan-then-execute strategy.
+
+        Phase 1 (Gather): build per-symbol contiguous date ranges.
+        Phase 2 (Plan):   query DB once per symbol to find missing data.
+        Phase 3 (Execute): download klines per-symbol; metrics per-date.
+        """
         run = run_id or generate_run_id("universe")
         db_file_path = self._validate_and_prepare_path(db_path, is_file=True)
         snapshots_to_process = snapshots if snapshots is not None else universe_def.daily_snapshots
@@ -416,65 +535,84 @@ class MarketDataService:
                 continue
             active_days.append((index, snapshot))
 
-        kline_stage = await self._run_kline_stage(
-            run_id=run,
-            snapshots=active_days,
-            db_path=db_file_path,
-            retry_config=retry_config,
-            incremental=incremental,
-            interval=interval,
-            max_api_workers=max_api_workers,
-            max_retries=max_retries,
-        )
-        day_reports = kline_stage["day_reports"]
-        stage_reports: dict[str, dict[str, Any]] = {"kline": kline_stage["stage_report"]}
-        stage_errors: list[dict[str, Any]] = list(kline_stage["stage_errors"])
+        # --- Phase 1: Gather symbol-date ranges ---
+        active_snapshots = [snap for _, snap in active_days]
+        symbol_date_ranges = gather_symbol_date_ranges(active_snapshots)
+
+        # --- Phase 2: Global plan (incremental check) ---
+        download_plan: UniverseDownloadPlan | None = None
+        if incremental and symbol_date_ranges:
+            db = Database(db_file_path)
+            await db.initialize()
+            try:
+                download_plan = await db.plan_universe_download(
+                    symbol_date_ranges=symbol_date_ranges,
+                    freq=interval,
+                    download_market_metrics=download_market_metrics,
+                )
+            finally:
+                await db.close()
+
+        # --- Phase 3: Execute ---
+        skipped_metrics_report = self._build_skipped_metrics_report(len(active_days))
 
         if download_market_metrics:
-            metrics_stage = await self._run_metrics_stage(
+            placeholder_day_reports: list[dict[str, Any]] = [{"date": snapshot.date, "index": index} for index, snapshot in active_days]
+            kline_stage, metrics_stage = await asyncio.gather(
+                self._run_kline_stage(
+                    run_id=run,
+                    snapshots=active_days,
+                    db_path=db_file_path,
+                    retry_config=retry_config,
+                    incremental=incremental,
+                    interval=interval,
+                    max_api_workers=max_api_workers,
+                    max_retries=max_retries,
+                    max_day_workers=max_day_workers,
+                    download_plan=download_plan,
+                ),
+                self._run_metrics_stage(
+                    run_id=run,
+                    snapshots=active_days,
+                    day_reports=placeholder_day_reports,
+                    db_path=db_file_path,
+                    api_request_delay=api_request_delay,
+                    vision_request_delay=vision_request_delay,
+                    max_api_workers=max_api_workers,
+                    max_vision_workers=max_vision_workers,
+                    incremental=incremental,
+                    max_day_workers=max_day_workers,
+                    download_plan=download_plan,
+                ),
+            )
+            day_reports = kline_stage["day_reports"]
+            metrics_by_date = {str(r["date"]): r.get("metrics") for r in metrics_stage["day_reports"] if r.get("metrics") is not None}
+            for report in day_reports:
+                metrics_data = metrics_by_date.get(str(report["date"]))
+                if metrics_data is not None:
+                    report["metrics"] = metrics_data
+
+            stage_reports: dict[str, dict[str, Any]] = {
+                "kline": kline_stage["stage_report"],
+                "metrics": metrics_stage["stage_report"],
+            }
+            stage_errors: list[dict[str, Any]] = list(kline_stage["stage_errors"]) + list(metrics_stage["stage_errors"])
+        else:
+            kline_stage = await self._run_kline_stage(
                 run_id=run,
                 snapshots=active_days,
-                day_reports=day_reports,
                 db_path=db_file_path,
-                api_request_delay=api_request_delay,
-                vision_request_delay=vision_request_delay,
-                max_api_workers=max_api_workers,
-                max_vision_workers=max_vision_workers,
+                retry_config=retry_config,
                 incremental=incremental,
+                interval=interval,
+                max_api_workers=max_api_workers,
+                max_retries=max_retries,
+                max_day_workers=max_day_workers,
+                download_plan=download_plan,
             )
-            day_reports = metrics_stage["day_reports"]
-            stage_reports["metrics"] = metrics_stage["stage_report"]
-            stage_errors.extend(metrics_stage["stage_errors"])
-        else:
-            stage_reports["metrics"] = {
-                "stage": "metrics",
-                "dataset": "market_metrics",
-                "status": "skipped",
-                "duration_ms": 0,
-                "days_total": len(active_days),
-                "days_complete": 0,
-                "days_partial": 0,
-                "days_error": 0,
-                "days_aborted": 0,
-                "sources": {
-                    "vision": {
-                        "status": "skipped",
-                        "aborted": False,
-                        "aborted_from_date": None,
-                        "days_complete": 0,
-                        "days_error": 0,
-                        "days_aborted": 0,
-                    },
-                    "funding_rate": {
-                        "status": "skipped",
-                        "aborted": False,
-                        "aborted_from_date": None,
-                        "days_complete": 0,
-                        "days_error": 0,
-                        "days_aborted": 0,
-                    },
-                },
-            }
+            day_reports = kline_stage["day_reports"]
+            stage_reports = {"kline": kline_stage["stage_report"], "metrics": skipped_metrics_report}
+            stage_errors = list(kline_stage["stage_errors"])
 
         return self._compose_universe_report(
             run_id=run,
@@ -501,7 +639,39 @@ class MarketDataService:
             max_retries=max_retries,
         )
 
-    async def _run_kline_stage(
+    @staticmethod
+    def _build_skipped_metrics_report(active_day_count: int) -> dict[str, Any]:
+        return {
+            "stage": "metrics",
+            "dataset": "market_metrics",
+            "status": "skipped",
+            "duration_ms": 0,
+            "days_total": active_day_count,
+            "days_complete": 0,
+            "days_partial": 0,
+            "days_error": 0,
+            "days_aborted": 0,
+            "sources": {
+                "vision": {
+                    "status": "skipped",
+                    "aborted": False,
+                    "aborted_from_date": None,
+                    "days_complete": 0,
+                    "days_error": 0,
+                    "days_aborted": 0,
+                },
+                "funding_rate": {
+                    "status": "skipped",
+                    "aborted": False,
+                    "aborted_from_date": None,
+                    "days_complete": 0,
+                    "days_error": 0,
+                    "days_aborted": 0,
+                },
+            },
+        }
+
+    async def _run_kline_stage(  # noqa: C901
         self,
         *,
         run_id: str,
@@ -512,14 +682,21 @@ class MarketDataService:
         interval: Freq,
         max_api_workers: int,
         max_retries: int,
+        max_day_workers: int = 3,
+        download_plan: UniverseDownloadPlan | None = None,
     ) -> dict[str, Any]:
-        """Run kline stage for all active universe days."""
+        """Run kline stage using a global symbol-centric plan.
+
+        When *download_plan* is provided, pre-computed ranges are passed
+        directly to the downloader, skipping per-day incremental queries.
+        """
         stage_started_at = time.perf_counter()
-        day_reports: list[dict[str, Any]] = []
         stage_errors: list[dict[str, Any]] = []
-        day_status_counts: dict[str, int] = defaultdict(int)
-        terminal_aborted = False
-        terminal_error_message: str | None = None
+
+        all_day_symbols: list[str] = []
+        for _, snap in snapshots:
+            all_day_symbols.extend(snap.active_symbols)
+        unique_symbols = sorted(set(all_day_symbols))
 
         logger.info(
             "download.stage_start",
@@ -529,166 +706,87 @@ class MarketDataService:
             status="start",
             duration_ms=0,
             days=len(snapshots),
+            symbols=len(unique_symbols),
+            max_api_workers=max_api_workers,
         )
 
-        for index, snapshot in snapshots:
-            symbols = list(snapshot.active_symbols)
-            day_started_at = time.perf_counter()
+        # Build precomputed_ranges from the global plan when available.
+        precomputed_ranges: dict[str, list[tuple[str, str]]] | None = None
+        effective_start = snapshots[0][1].date if snapshots else ""
+        effective_end = snapshots[-1][1].date if snapshots else ""
 
-            if terminal_aborted:
-                reason = terminal_error_message or "terminal_rate_limit_aborted"
-                missing_periods = [{"symbol": symbol, "period": f"{snapshot.date} - {snapshot.date}", "reason": reason} for symbol in symbols]
-                day_report = {
-                    "index": index,
-                    "date": snapshot.date,
-                    "total_symbols": len(symbols),
-                    "successful_symbols": 0,
-                    "failed_symbols": symbols,
-                    "missing_periods": missing_periods,
-                }
-                day_reports.append(day_report)
-                day_status_counts["aborted"] += 1
-                logger.warning(
-                    "download.day_done",
-                    run=run_id,
-                    stage="kline",
-                    dataset="kline",
-                    status="aborted",
-                    duration_ms=0,
-                    date=snapshot.date,
-                    total_symbols=len(symbols),
-                    successful_symbols=0,
-                    failed_symbols=len(symbols),
-                    terminal=True,
-                    error=reason,
-                )
-                continue
+        if download_plan is not None:
+            precomputed_ranges = {symbol: [(str(s), str(e)) for s, e in plan.download_ranges] for symbol, plan in download_plan.kline.items()}
 
-            logger.info(
-                "download.day_start",
-                run=run_id,
-                stage="kline",
-                dataset="kline",
-                status="start",
-                duration_ms=0,
-                date=snapshot.date,
-                total_symbols=len(symbols),
+        successful_symbols_set: set[str] = set()
+        failed_symbols_set: set[str] = set()
+        failed_symbol_reasons: dict[str, str] = {}
+        kline_missing_periods: list[dict[str, Any]] = []
+        terminal_aborted = False
+
+        try:
+            kline_report = await self.kline_downloader.download_multiple_symbols(
+                symbols=unique_symbols,
+                start_time=effective_start,
+                end_time=effective_end,
+                interval=interval,
+                db_path=db_path,
+                max_workers=max_api_workers,
+                retry_config=retry_config or RetryConfig(max_retries=max_retries),
+                incremental=incremental,
+                run_id=run_id,
+                precomputed_ranges=precomputed_ranges,
+                source="vision",
             )
+            kline_missing_periods = [mp for mp in kline_report.missing_periods if isinstance(mp, dict)]
+            successful_symbols_set = set(unique_symbols) - set(kline_report.failed_symbols)
+            failed_symbols_set = set(kline_report.failed_symbols)
+            for mp in kline_missing_periods:
+                if isinstance(mp, dict):
+                    failed_symbol_reasons[str(mp.get("symbol", ""))] = str(mp.get("reason", "unknown"))
 
-            try:
-                kline_report = await self.get_perpetual_data(
-                    symbols=symbols,
-                    start_time=snapshot.date,
-                    end_time=snapshot.date,
-                    db_path=db_path,
-                    interval=interval,
-                    max_workers=max_api_workers,
-                    max_retries=max_retries,
-                    retry_config=retry_config,
-                    incremental=incremental,
+        except RateLimitError as exc:
+            terminal_aborted = True
+            stage_errors.append(
+                self._normalize_stage_error(
                     run_id=run_id,
-                )
-                day_report = {
-                    "index": index,
-                    "date": snapshot.date,
-                    "total_symbols": kline_report.total_symbols,
-                    "successful_symbols": kline_report.successful_symbols,
-                    "failed_symbols": list(kline_report.failed_symbols),
-                    "missing_periods": list(kline_report.missing_periods),
-                }
-                day_reports.append(day_report)
-                status = "complete" if not kline_report.failed_symbols and not kline_report.missing_periods else "partial"
-                day_status_counts[status] += 1
-                logger.info(
-                    "download.day_done",
-                    run=run_id,
                     stage="kline",
                     dataset="kline",
-                    status=status,
-                    duration_ms=int((time.perf_counter() - day_started_at) * 1000),
-                    date=snapshot.date,
-                    total_symbols=kline_report.total_symbols,
-                    successful_symbols=kline_report.successful_symbols,
-                    failed_symbols=len(kline_report.failed_symbols),
-                )
-            except RateLimitError as exc:
-                terminal_aborted = True
-                terminal_error_message = str(exc)
-                stage_errors.append(
-                    self._normalize_stage_error(
-                        run_id=run_id,
-                        stage="kline",
-                        dataset="kline",
-                        date=snapshot.date,
-                        error=str(exc),
-                        terminal=True,
-                    )
-                )
-                missing_periods = [{"symbol": symbol, "period": f"{snapshot.date} - {snapshot.date}", "reason": str(exc)} for symbol in symbols]
-                day_report = {
-                    "index": index,
-                    "date": snapshot.date,
-                    "total_symbols": len(symbols),
-                    "successful_symbols": 0,
-                    "failed_symbols": symbols,
-                    "missing_periods": missing_periods,
-                }
-                day_reports.append(day_report)
-                day_status_counts["aborted"] += 1
-                logger.error(
-                    "download.day_done",
-                    run=run_id,
-                    stage="kline",
-                    dataset="kline",
-                    status="aborted",
-                    duration_ms=int((time.perf_counter() - day_started_at) * 1000),
-                    date=snapshot.date,
-                    total_symbols=len(symbols),
-                    successful_symbols=0,
-                    failed_symbols=len(symbols),
+                    error=str(exc),
                     terminal=True,
-                    error=str(exc),
                 )
-            except Exception as exc:  # noqa: BLE001
-                stage_errors.append(
-                    self._normalize_stage_error(
-                        run_id=run_id,
-                        stage="kline",
-                        dataset="kline",
-                        date=snapshot.date,
-                        error=str(exc),
-                        terminal=False,
-                    )
-                )
-                missing_periods = [{"symbol": symbol, "period": f"{snapshot.date} - {snapshot.date}", "reason": str(exc)} for symbol in symbols]
-                day_report = {
-                    "index": index,
-                    "date": snapshot.date,
-                    "total_symbols": len(symbols),
-                    "successful_symbols": 0,
-                    "failed_symbols": symbols,
-                    "missing_periods": missing_periods,
-                }
-                day_reports.append(day_report)
-                day_status_counts["error"] += 1
-                logger.error(
-                    "download.day_done",
-                    run=run_id,
+            )
+            failed_symbols_set = set(unique_symbols)
+            for s in unique_symbols:
+                failed_symbol_reasons[s] = str(exc)
+        except Exception as exc:  # noqa: BLE001
+            stage_errors.append(
+                self._normalize_stage_error(
+                    run_id=run_id,
                     stage="kline",
                     dataset="kline",
-                    status="error",
-                    duration_ms=int((time.perf_counter() - day_started_at) * 1000),
-                    date=snapshot.date,
-                    total_symbols=len(symbols),
-                    successful_symbols=0,
-                    failed_symbols=len(symbols),
-                    terminal=False,
                     error=str(exc),
+                    terminal=False,
                 )
+            )
+            failed_symbols_set = set(unique_symbols)
+            for s in unique_symbols:
+                failed_symbol_reasons[s] = str(exc)
 
-        total_symbols = sum(int(report.get("total_symbols", 0)) for report in day_reports)
-        total_success = sum(int(report.get("successful_symbols", 0)) for report in day_reports)
-        total_failures = sum(len(cast(list[str], report.get("failed_symbols", []))) for report in day_reports)
+        # Reconstruct per-day reports from symbol results.
+        day_reports, day_status_counts = self._reconstruct_kline_day_reports(
+            snapshots=snapshots,
+            successful_symbols=successful_symbols_set,
+            failed_symbols=failed_symbols_set,
+            failed_reasons=failed_symbol_reasons,
+            missing_periods=kline_missing_periods,
+            kline_plan=download_plan.kline if download_plan else None,
+            terminal_aborted=terminal_aborted,
+        )
+
+        total_symbols = sum(int(r.get("total_symbols", 0)) for r in day_reports)
+        total_success = sum(int(r.get("successful_symbols", 0)) for r in day_reports)
+        total_failures = sum(len(cast(list[str], r.get("failed_symbols", []))) for r in day_reports)
 
         if not day_reports:
             stage_status = "skipped"
@@ -732,6 +830,90 @@ class MarketDataService:
             "stage_errors": stage_errors,
         }
 
+    @staticmethod
+    def _index_missing_periods_by_date_symbol(
+        missing_periods: list[dict[str, Any]],
+    ) -> dict[tuple[str, str], list[dict[str, Any]]]:
+        index: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+        for payload in missing_periods:
+            symbol = str(payload.get("symbol", "")).strip()
+            if not symbol:
+                continue
+            date = payload.get("date")
+            if isinstance(date, str) and date:
+                index[(date, symbol)].append(payload)
+                continue
+
+            period_text = str(payload.get("period", ""))
+            period_start = period_text.split(" - ", 1)[0].strip()
+            if period_start:
+                index[(period_start, symbol)].append(payload)
+        return index
+
+    @staticmethod
+    def _reconstruct_kline_day_reports(
+        *,
+        snapshots: list[tuple[int, UniverseDailySnapshot]],
+        successful_symbols: set[str],
+        failed_symbols: set[str],
+        failed_reasons: dict[str, str],
+        missing_periods: list[dict[str, Any]],
+        kline_plan: dict | None,
+        terminal_aborted: bool,
+    ) -> tuple[list[dict[str, Any]], dict[str, int]]:
+        """Reconstruct per-day reports from symbol-level download results."""
+        day_reports: list[dict[str, Any]] = []
+        day_status_counts: dict[str, int] = defaultdict(int)
+        missing_by_date_symbol = MarketDataService._index_missing_periods_by_date_symbol(missing_periods)
+
+        for index, snapshot in snapshots:
+            day_symbols = list(snapshot.active_symbols)
+            day_successful: list[str] = []
+            day_failed: list[str] = []
+            day_missing: list[dict[str, Any]] = []
+
+            for s in day_symbols:
+                symbol_day_missing = missing_by_date_symbol.get((snapshot.date, s), [])
+                if symbol_day_missing:
+                    day_failed.append(s)
+                    day_missing.extend(symbol_day_missing)
+                    continue
+                if s in failed_symbols:
+                    day_failed.append(s)
+                    reason = failed_reasons.get(s, "unknown")
+                    day_missing.append(
+                        {
+                            "symbol": s,
+                            "period": f"{snapshot.date} - {snapshot.date}",
+                            "reason": reason,
+                        }
+                    )
+                else:
+                    day_successful.append(s)
+
+            if terminal_aborted and not day_successful:
+                status = "aborted"
+            elif day_failed and not day_successful:
+                status = "error"
+            elif day_failed or day_missing:
+                status = "partial"
+            else:
+                status = "complete"
+
+            day_status_counts[status] += 1
+            day_reports.append(
+                {
+                    "index": index,
+                    "date": snapshot.date,
+                    "total_symbols": len(day_symbols),
+                    "successful_symbols": len(day_successful),
+                    "failed_symbols": day_failed,
+                    "missing_periods": day_missing,
+                }
+            )
+
+        return day_reports, dict(day_status_counts)
+
     async def _run_metrics_stage(  # noqa: C901
         self,
         *,
@@ -744,13 +926,19 @@ class MarketDataService:
         max_api_workers: int,
         max_vision_workers: int,
         incremental: bool,
+        max_day_workers: int = 3,
+        download_plan: UniverseDownloadPlan | None = None,
     ) -> dict[str, Any]:
-        """Run metrics stage with source-level isolation and terminal abort per source."""
+        """Run metrics stage with concurrent day processing and per-source abort."""
         stage_started_at = time.perf_counter()
         day_status_counts: dict[str, int] = defaultdict(int)
         stage_errors: list[dict[str, Any]] = []
         day_report_by_date = {str(report["date"]): report for report in day_reports}
 
+        source_abort_events: dict[str, asyncio.Event] = {
+            "vision": asyncio.Event(),
+            "funding_rate": asyncio.Event(),
+        }
         source_state: dict[str, dict[str, Any]] = {
             "vision": {
                 "aborted": False,
@@ -768,6 +956,8 @@ class MarketDataService:
             },
         }
 
+        day_semaphore = asyncio.Semaphore(max_day_workers)
+
         logger.info(
             "download.stage_start",
             run=run_id,
@@ -777,24 +967,94 @@ class MarketDataService:
             duration_ms=0,
             days=len(snapshots),
             incremental=incremental,
+            max_day_workers=max_day_workers,
         )
 
-        for _, snapshot in snapshots:
-            day_metrics, day_errors, source_aborts = await self._download_market_metrics_for_date(
-                date=snapshot.date,
-                symbols=snapshot.active_symbols,
-                db_path=db_path,
-                api_request_delay=api_request_delay,
-                vision_request_delay=vision_request_delay,
-                max_api_workers=max_api_workers,
-                max_vision_workers=max_vision_workers,
-                incremental=incremental,
-                run_id=run_id,
-                skip_vision=bool(source_state["vision"]["aborted"]),
-                skip_funding_rate=bool(source_state["funding_rate"]["aborted"]),
-            )
+        # Pre-compute per-date symbols needing vision/funding from global plan.
+        vision_needed_by_date: dict[str, set[str]] | None = None
+        funding_needed_by_date: dict[str, set[str]] | None = None
 
-            report = day_report_by_date.get(snapshot.date)
+        if download_plan is not None:
+            active_day_bounds: dict[str, tuple[int, int]] = {
+                snap.date: (int(self._date_to_timestamp_start(snap.date)), int(self._date_to_timestamp_end(snap.date))) for _, snap in snapshots
+            }
+            vision_needed_by_date = {}
+            for symbol, vplan in download_plan.vision.items():
+                for d in vplan.missing_dates:
+                    if d in active_day_bounds:
+                        vision_needed_by_date.setdefault(d, set()).add(symbol)
+
+            funding_needed_by_date = {}
+            for symbol, fplan in download_plan.funding_rate.items():
+                for start_ts, end_ts in fplan.download_ranges:
+                    range_start = int(start_ts)
+                    range_end = int(end_ts)
+                    # Map range to active universe days using date span.
+                    # end_ts is generally exclusive; clamp by -1ms to get the covered final day.
+                    covered_end = max(range_start, range_end - 1)
+                    start_day = datetime.fromtimestamp(range_start / 1000, tz=UTC).date()
+                    end_day = datetime.fromtimestamp(covered_end / 1000, tz=UTC).date()
+                    current_day = start_day
+                    while current_day <= end_day:
+                        current_day_str = current_day.strftime("%Y-%m-%d")
+                        if current_day_str in active_day_bounds:
+                            funding_needed_by_date.setdefault(current_day_str, set()).add(symbol)
+                        current_day += timedelta(days=1)
+
+        metrics_results: list[tuple[dict[str, Any], list[dict[str, Any]], dict[str, bool], str] | None] = [None] * len(snapshots)
+
+        async def process_metrics_day(pos: int, snapshot: UniverseDailySnapshot) -> None:
+            async with day_semaphore:
+                day_symbols = list(snapshot.active_symbols)
+                day_symbol_set = set(day_symbols)
+                vision_terminal_abort = source_abort_events["vision"].is_set()
+                funding_terminal_abort = source_abort_events["funding_rate"].is_set()
+
+                vision_symbols_for_day = day_symbols
+                funding_symbols_for_day = day_symbols
+
+                if vision_needed_by_date is not None:
+                    vision_symbols_for_day = sorted(day_symbol_set & vision_needed_by_date.get(snapshot.date, set()))
+                if funding_needed_by_date is not None:
+                    funding_symbols_for_day = sorted(day_symbol_set & funding_needed_by_date.get(snapshot.date, set()))
+
+                skip_vision = vision_terminal_abort or not vision_symbols_for_day
+                skip_funding = funding_terminal_abort or not funding_symbols_for_day
+
+                day_metrics, day_errors, source_aborts = await self._download_market_metrics_for_date(
+                    date=snapshot.date,
+                    symbols=day_symbols,
+                    db_path=db_path,
+                    api_request_delay=api_request_delay,
+                    vision_request_delay=vision_request_delay,
+                    max_api_workers=max_api_workers,
+                    max_vision_workers=max_vision_workers,
+                    incremental=incremental,
+                    run_id=run_id,
+                    skip_vision=skip_vision,
+                    skip_funding_rate=skip_funding,
+                    vision_symbols=vision_symbols_for_day,
+                    funding_symbols=funding_symbols_for_day,
+                    skip_vision_terminal=vision_terminal_abort,
+                    skip_funding_terminal=funding_terminal_abort,
+                )
+
+                for source_name in ("vision", "funding_rate"):
+                    if source_aborts.get(source_name):
+                        source_abort_events[source_name].set()
+
+                metrics_results[pos] = (day_metrics, day_errors, source_aborts, snapshot.date)
+
+        async with asyncio.TaskGroup() as tg:
+            for pos, (_, snapshot) in enumerate(snapshots):
+                tg.create_task(process_metrics_day(pos, snapshot))
+
+        for result in metrics_results:
+            if result is None:
+                continue
+            day_metrics, day_errors, source_aborts, date = result
+
+            report = day_report_by_date.get(date)
             if report is not None:
                 report["metrics"] = day_metrics
 
@@ -815,7 +1075,7 @@ class MarketDataService:
                 if source_aborts.get(source_name):
                     source_state[source_name]["aborted"] = True
                     if source_state[source_name]["aborted_from_date"] is None:
-                        source_state[source_name]["aborted_from_date"] = snapshot.date
+                        source_state[source_name]["aborted_from_date"] = date
 
         if not snapshots:
             stage_status = "skipped"
@@ -1379,9 +1639,9 @@ class MarketDataService:
     async def check_symbol_full_day_available_on_date(self, symbol: str, date: str, strict: bool = False) -> bool:
         """Check whether a symbol has complete day coverage on a specific date."""
         try:
-            start_time = self._date_to_timestamp_start(date)
-            end_time = self._date_to_timestamp_end(date)
-            day_start_ts = int(start_time)
+            start_time = int(self._date_to_timestamp_start(date))
+            end_time = int(self._date_to_timestamp_end(date))
+            day_start_ts = start_time
 
             klines = await asyncio.wait_for(
                 self.client.futures_klines(
@@ -1421,8 +1681,8 @@ class MarketDataService:
     async def check_symbol_exists_on_date(self, symbol: str, date: str, strict: bool = False) -> bool:
         """Check whether a symbol has data on a specific date."""
         try:
-            start_time = self._date_to_timestamp_start(date)
-            end_time = self._date_to_timestamp_end(date)
+            start_time = int(self._date_to_timestamp_start(date))
+            end_time = int(self._date_to_timestamp_end(date))
 
             klines = await asyncio.wait_for(
                 self.client.futures_klines(
@@ -1486,7 +1746,7 @@ class MarketDataService:
                 interval="1m",
                 startTime=start_time,
                 endTime=end_time,
-                limit=1,
+                limit=1500,
             )
 
         try:
@@ -1503,14 +1763,145 @@ class MarketDataService:
         if not klines:
             return "no_kline_on_date"
 
-        first_open_time = int(klines[0][0])
-        if first_open_time == day_start_ts:
-            return "active"
-        return "not_full_day_on_date"
+        expected_points = _DAY_MS // _MINUTE_MS
+        if len(klines) != expected_points:
+            return "not_full_day_on_date"
+
+        try:
+            open_times = [int(kline[0]) for kline in klines]
+        except (TypeError, ValueError, IndexError):
+            return "not_full_day_on_date"
+
+        expected_start = day_start_ts
+        expected_end = day_start_ts + (expected_points - 1) * _MINUTE_MS
+        if open_times[0] != expected_start or open_times[-1] != expected_end:
+            return "not_full_day_on_date"
+
+        for index, open_time in enumerate(open_times):
+            if open_time != expected_start + index * _MINUTE_MS:
+                return "not_full_day_on_date"
+
+        return "active"
+
+    async def _scan_symbol_date_statuses(  # noqa: C901
+        self,
+        symbol: str,
+        start_date: str,
+        end_date: str,
+        endpoint_max_workers: int = 5,
+    ) -> dict[str, str]:
+        """Classify each date in a range for one symbol with one range scan."""
+        import pandas as pd
+
+        all_dates = [date.strftime("%Y-%m-%d") for date in pd.date_range(start=start_date, end=end_date, freq="D", tz="UTC")]
+        if not all_dates:
+            return {}
+
+        day_boundaries: dict[str, tuple[int, int]] = {}
+        for date_str in all_dates:
+            day_start = int(self._date_to_timestamp_start(date_str))
+            day_end = day_start + _DAY_MS
+            day_boundaries[date_str] = (day_start, day_end)
+
+        day_stats: dict[str, _DayScanStats] = {date_str: {"count": 0, "first": None, "last": None, "prev": None, "broken": False} for date_str in all_dates}
+
+        start_ts = str(int(self._date_to_timestamp_start(start_date)))
+        end_ts = str(int(self._date_to_timestamp_end(end_date)))
+
+        try:
+            async for ticker in self.kline_downloader.download_single_symbol(
+                symbol=symbol,
+                start_ts=start_ts,
+                end_ts=end_ts,
+                interval=Freq.m1,
+                klines_type=HistoricalKlinesType.FUTURES,
+                endpoint_max_workers=endpoint_max_workers,
+            ):
+                open_time = int(ticker.open_time)
+                date_key = datetime.fromtimestamp(open_time / 1000, tz=UTC).strftime("%Y-%m-%d")
+                stats = day_stats.get(date_key)
+                if stats is None:
+                    continue
+
+                stats["count"] += 1
+                if stats["first"] is None:
+                    stats["first"] = open_time
+                previous = stats["prev"]
+                if previous is not None and open_time - previous != _MINUTE_MS:
+                    stats["broken"] = True
+                stats["prev"] = open_time
+                stats["last"] = open_time
+        except RateLimitError as exc:
+            raise MarketDataFetchError(f"Rate limit circuit breaker tripped scanning {symbol} {start_date}~{end_date}: {exc}") from exc
+        except Exception as exc:
+            raise MarketDataFetchError(f"Failed to scan symbol {symbol} {start_date}~{end_date}: {exc}") from exc
+
+        expected_points = _DAY_MS // _MINUTE_MS
+        status_by_date: dict[str, str] = {}
+        for date_str in all_dates:
+            stats = day_stats[date_str]
+            count = stats["count"]
+            if count == 0:
+                status_by_date[date_str] = "no_kline_on_date"
+                continue
+
+            day_start, day_end = day_boundaries[date_str]
+            first_open = stats["first"] if stats["first"] is not None else -1
+            last_open = stats["last"] if stats["last"] is not None else -1
+            continuous = (not bool(stats["broken"])) and first_open == day_start and last_open == day_end - _MINUTE_MS
+            status_by_date[date_str] = "active" if continuous and count == expected_points else "not_full_day_on_date"
+
+        return status_by_date
+
+    async def _check_metrics_asof_ready_on_date(self, symbol: str, date: str) -> bool:
+        """Return True when required metrics predata exists for define-stage asof readiness."""
+        day_start_ts = int(self._date_to_timestamp_start(date))
+
+        async def has_funding_rate_data() -> bool:
+            lookback_start = day_start_ts - _ASOF_LOOKBACK_DAYS["funding_rate"] * _DAY_MS
+            data = await self.metrics_downloader.download_funding_rate(
+                symbol=symbol,
+                start_ts=lookback_start,
+                end_ts=day_start_ts,
+                limit=1,
+            )
+            return bool(data)
+
+        async def has_open_interest_data() -> bool:
+            lookback_start = day_start_ts - _ASOF_LOOKBACK_DAYS["open_interest"] * _DAY_MS
+            data = await self.metrics_downloader.download_open_interest(
+                symbol=symbol,
+                start_ts=lookback_start,
+                end_ts=day_start_ts,
+                limit=1,
+            )
+            return bool(data)
+
+        async def has_lsr_data(ratio_type: str) -> bool:
+            lookback_start = day_start_ts - _ASOF_LOOKBACK_DAYS["long_short_ratio"] * _DAY_MS
+            data = await self.metrics_downloader.download_long_short_ratio(
+                symbol=symbol,
+                ratio_type=ratio_type,
+                start_ts=lookback_start,
+                end_ts=day_start_ts,
+                limit=1,
+            )
+            return bool(data)
+
+        try:
+            checks = [
+                has_funding_rate_data(),
+                has_open_interest_data(),
+                *[has_lsr_data(ratio_type) for ratio_type in _LSR_RATIO_TYPES],
+            ]
+            results = await asyncio.gather(*checks)
+            return all(results)
+        except Exception as exc:
+            raise MarketDataFetchError(f"Failed to check metrics asof readiness for {symbol} on {date}: {exc}") from exc
 
     # ==================== 私有辅助方法 ====================
 
-    async def _download_market_metrics_for_date(
+    async def _download_market_metrics_for_date(  # noqa: C901
         self,
         date: str,
         symbols: list[str],
@@ -1523,6 +1914,10 @@ class MarketDataService:
         run_id: str | None = None,
         skip_vision: bool = False,
         skip_funding_rate: bool = False,
+        vision_symbols: list[str] | None = None,
+        funding_symbols: list[str] | None = None,
+        skip_vision_terminal: bool = False,
+        skip_funding_terminal: bool = False,
     ) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, bool]]:
         """Download metrics for one date and symbol list."""
         if not symbols:
@@ -1546,18 +1941,23 @@ class MarketDataService:
         day_started_at = time.perf_counter()
         errors: list[dict[str, Any]] = []
         source_aborts = {"vision": False, "funding_rate": False}
+        effective_vision_symbols = vision_symbols if vision_symbols is not None else symbols
+        effective_funding_symbols = funding_symbols if funding_symbols is not None else symbols
+        effective_skip_vision = skip_vision or not effective_vision_symbols
+        effective_skip_funding = skip_funding_rate or not effective_funding_symbols
+
         source_payloads: dict[str, dict[str, Any]] = {
             "vision": {
-                "status": "skipped" if skip_vision else "pending",
+                "status": "skipped" if effective_skip_vision else "pending",
                 "dataset": "vision-metrics",
                 "duration_ms": 0,
-                "terminal": bool(skip_vision),
+                "terminal": bool(skip_vision_terminal),
             },
             "funding_rate": {
-                "status": "skipped" if skip_funding_rate else "pending",
+                "status": "skipped" if effective_skip_funding else "pending",
                 "dataset": "funding_rate",
                 "duration_ms": 0,
-                "terminal": bool(skip_funding_rate),
+                "terminal": bool(skip_funding_terminal),
             },
         }
 
@@ -1589,6 +1989,7 @@ class MarketDataService:
             source: str,
             dataset: str,
             runner: Any,
+            source_symbols: list[str],
         ) -> None:
             source_started_at = time.perf_counter()
             logger.info(
@@ -1599,7 +2000,7 @@ class MarketDataService:
                 status="start",
                 duration_ms=0,
                 date=date,
-                total_symbols=len(symbols),
+                total_symbols=len(source_symbols),
             )
             try:
                 await runner
@@ -1617,7 +2018,7 @@ class MarketDataService:
                     status="complete",
                     duration_ms=source_payloads[source]["duration_ms"],
                     date=date,
-                    total_symbols=len(symbols),
+                    total_symbols=len(source_symbols),
                 )
             except RateLimitError as exc:
                 source_aborts[source] = True
@@ -1647,7 +2048,7 @@ class MarketDataService:
                     status="aborted",
                     duration_ms=source_payloads[source]["duration_ms"],
                     date=date,
-                    total_symbols=len(symbols),
+                    total_symbols=len(source_symbols),
                     terminal=True,
                     error=str(exc),
                 )
@@ -1678,82 +2079,108 @@ class MarketDataService:
                     status="error",
                     duration_ms=source_payloads[source]["duration_ms"],
                     date=date,
-                    total_symbols=len(symbols),
+                    total_symbols=len(source_symbols),
                     terminal=False,
                     error=str(exc),
                 )
 
-        if skip_vision:
-            source_payloads["vision"] = {
-                "status": "aborted",
-                "dataset": "vision-metrics",
-                "duration_ms": 0,
-                "terminal": True,
-                "error": "source_aborted_after_terminal_rate_limit",
-            }
-            logger.warning(
-                "download.source_done",
-                run=run_id,
-                stage="metrics",
-                dataset="vision-metrics",
-                status="aborted",
-                duration_ms=0,
-                date=date,
-                total_symbols=len(symbols),
-                terminal=True,
-                error="source_aborted_after_terminal_rate_limit",
-            )
-        else:
-            await run_source(
-                source="vision",
-                dataset="vision-metrics",
-                runner=self.vision_downloader.download_metrics_batch(
-                    symbols=symbols,
-                    start_date=date,
-                    end_date=date,
-                    db_path=str(db_path),
-                    request_delay=vision_request_delay,
-                    max_workers=max_vision_workers,
-                    incremental=incremental,
-                    run_id=run_id,
-                ),
-            )
+        if effective_skip_vision:
+            if skip_vision_terminal:
+                source_payloads["vision"] = {
+                    "status": "aborted",
+                    "dataset": "vision-metrics",
+                    "duration_ms": 0,
+                    "terminal": True,
+                    "error": "source_aborted_after_terminal_rate_limit",
+                }
+                logger.warning(
+                    "download.source_done",
+                    run=run_id,
+                    stage="metrics",
+                    dataset="vision-metrics",
+                    status="aborted",
+                    duration_ms=0,
+                    date=date,
+                    total_symbols=len(effective_vision_symbols),
+                    terminal=True,
+                    error="source_aborted_after_terminal_rate_limit",
+                )
+            else:
+                source_payloads["vision"] = {
+                    "status": "skipped",
+                    "dataset": "vision-metrics",
+                    "duration_ms": 0,
+                    "terminal": False,
+                }
 
-        if skip_funding_rate:
-            source_payloads["funding_rate"] = {
-                "status": "aborted",
-                "dataset": "funding_rate",
-                "duration_ms": 0,
-                "terminal": True,
-                "error": "source_aborted_after_terminal_rate_limit",
-            }
-            logger.warning(
-                "download.source_done",
-                run=run_id,
-                stage="metrics",
-                dataset="funding_rate",
-                status="aborted",
-                duration_ms=0,
-                date=date,
-                total_symbols=len(symbols),
-                terminal=True,
-                error="source_aborted_after_terminal_rate_limit",
+        if effective_skip_funding:
+            if skip_funding_terminal:
+                source_payloads["funding_rate"] = {
+                    "status": "aborted",
+                    "dataset": "funding_rate",
+                    "duration_ms": 0,
+                    "terminal": True,
+                    "error": "source_aborted_after_terminal_rate_limit",
+                }
+                logger.warning(
+                    "download.source_done",
+                    run=run_id,
+                    stage="metrics",
+                    dataset="funding_rate",
+                    status="aborted",
+                    duration_ms=0,
+                    date=date,
+                    total_symbols=len(effective_funding_symbols),
+                    terminal=True,
+                    error="source_aborted_after_terminal_rate_limit",
+                )
+            else:
+                source_payloads["funding_rate"] = {
+                    "status": "skipped",
+                    "dataset": "funding_rate",
+                    "duration_ms": 0,
+                    "terminal": False,
+                }
+
+        concurrent_tasks: list[Any] = []
+        if not effective_skip_vision:
+            concurrent_tasks.append(
+                run_source(
+                    source="vision",
+                    dataset="vision-metrics",
+                    runner=self.vision_downloader.download_metrics_batch(
+                        symbols=effective_vision_symbols,
+                        start_date=date,
+                        end_date=date,
+                        db_path=str(db_path),
+                        request_delay=vision_request_delay,
+                        max_workers=max_vision_workers,
+                        incremental=incremental,
+                        run_id=run_id,
+                    ),
+                    source_symbols=effective_vision_symbols,
+                )
             )
-        else:
-            await run_source(
-                source="funding_rate",
-                dataset="funding_rate",
-                runner=self.metrics_downloader.download_funding_rate_batch(
-                    symbols=symbols,
-                    start_time=date,
-                    end_time=date,
-                    db_path=str(db_path),
-                    request_delay=api_request_delay,
-                    max_workers=max_api_workers,
-                    incremental=incremental,
-                    run_id=run_id,
-                ),
+        if not effective_skip_funding:
+            concurrent_tasks.append(
+                run_source(
+                    source="funding_rate",
+                    dataset="funding_rate",
+                    runner=self.metrics_downloader.download_funding_rate_batch(
+                        symbols=effective_funding_symbols,
+                        start_time=date,
+                        end_time=date,
+                        db_path=str(db_path),
+                        request_delay=api_request_delay,
+                        max_workers=max_api_workers,
+                        incremental=incremental,
+                        run_id=run_id,
+                    ),
+                    source_symbols=effective_funding_symbols,
+                )
             )
+        if concurrent_tasks:
+            await asyncio.gather(*concurrent_tasks)
 
         source_statuses = {str(payload.get("status")) for payload in source_payloads.values()}
         if source_statuses.issubset({"complete", "skipped"}):

--- a/tests/test_market_service_symbol_check.py
+++ b/tests/test_market_service_symbol_check.py
@@ -12,6 +12,43 @@ from cryptoservice.exceptions import MarketDataFetchError
 from cryptoservice.services import MarketDataService
 
 
+class _FakeAioHttpResponse:
+    def __init__(self, *, payload: str, status: int = 200) -> None:
+        self._payload = payload
+        self._status = status
+
+    async def __aenter__(self) -> _FakeAioHttpResponse:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        if self._status >= 400:
+            raise RuntimeError(f"http error status={self._status}")
+
+    async def text(self) -> str:
+        return self._payload
+
+
+class _FakeAioHttpSession:
+    def __init__(self, responses: list[_FakeAioHttpResponse], calls: list[dict[str, object]]) -> None:
+        self._responses = responses
+        self._calls = calls
+
+    async def __aenter__(self) -> _FakeAioHttpSession:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def get(self, url: str, *, params: dict[str, str] | None = None) -> _FakeAioHttpResponse:
+        self._calls.append({"url": url, "params": dict(params or {})})
+        if not self._responses:
+            raise AssertionError("No mocked responses left")
+        return self._responses.pop(0)
+
+
 @pytest.mark.asyncio
 async def test_check_symbol_exists_on_date_timeout_raises_in_strict_mode(monkeypatch) -> None:
     """Strict mode should fail fast when one symbol check stalls."""
@@ -62,3 +99,107 @@ async def test_check_symbol_full_day_available_on_date_timeout_raises_in_strict_
 
     with pytest.raises(MarketDataFetchError, match="Timed out checking full-day coverage for symbol BTCUSDT on 2024-10-01"):
         await service.check_symbol_full_day_available_on_date("BTCUSDT", "2024-10-01", strict=True)
+
+
+@pytest.mark.asyncio
+async def test_check_symbol_date_status_active_only_when_all_1m_points_exist() -> None:
+    """Status should be active only with exact full-day 1m coverage."""
+    service = MarketDataService(AsyncMock())
+    day_start = int(service._date_to_timestamp_start("2024-10-01"))
+    full_day_klines = [[day_start + i * 60_000] for i in range(24 * 60)]
+    setattr(service.kline_downloader, "_handle_async_request_with_retry", AsyncMock(return_value=full_day_klines))
+
+    status = await service._check_symbol_date_status("BTCUSDT", "2024-10-01", endpoint_max_workers=3)
+    assert status == "active"
+
+
+@pytest.mark.asyncio
+async def test_check_symbol_date_status_marks_not_full_day_when_one_1m_point_missing() -> None:
+    """Any missing minute should disqualify a symbol from active on that date."""
+    service = MarketDataService(AsyncMock())
+    day_start = int(service._date_to_timestamp_start("2024-10-01"))
+    klines_with_gap = [[day_start + i * 60_000] for i in range(24 * 60) if i != 777]
+    setattr(service.kline_downloader, "_handle_async_request_with_retry", AsyncMock(return_value=klines_with_gap))
+
+    status = await service._check_symbol_date_status("BTCUSDT", "2024-10-01", endpoint_max_workers=3)
+    assert status == "not_full_day_on_date"
+
+
+@pytest.mark.asyncio
+async def test_get_vision_kline_available_dates_uses_s3_listing_with_pagination(monkeypatch) -> None:
+    """Vision listing should use S3 API with continuation token pagination."""
+    service = MarketDataService(AsyncMock())
+    calls: list[dict[str, object]] = []
+    responses = [
+        _FakeAioHttpResponse(
+            payload=(
+                '<?xml version="1.0" encoding="UTF-8"?>'
+                '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+                "<IsTruncated>true</IsTruncated>"
+                "<NextContinuationToken>page-2</NextContinuationToken>"
+                "<Contents><Key>data/futures/um/daily/klines/BTCUSDT/1m/BTCUSDT-1m-2024-10-01.zip</Key></Contents>"
+                "<Contents><Key>data/futures/um/daily/klines/BTCUSDT/1m/BTCUSDT-1m-2024-10-01.zip.CHECKSUM</Key></Contents>"
+                "</ListBucketResult>"
+            )
+        ),
+        _FakeAioHttpResponse(
+            payload=(
+                '<?xml version="1.0" encoding="UTF-8"?>'
+                '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+                "<IsTruncated>false</IsTruncated>"
+                "<Contents><Key>data/futures/um/daily/klines/BTCUSDT/1m/BTCUSDT-1m-2024-10-02.zip</Key></Contents>"
+                "<Contents><Key>data/futures/um/daily/klines/BTCUSDT/1m/BTCUSDT-1m-2024-10-03.zip</Key></Contents>"
+                "</ListBucketResult>"
+            )
+        ),
+    ]
+
+    monkeypatch.setattr(
+        market_service_module.aiohttp,
+        "ClientSession",
+        lambda *args, **kwargs: _FakeAioHttpSession(list(responses), calls),
+    )
+
+    dates = await service._get_vision_kline_available_dates(
+        symbol="BTCUSDT",
+        start_date="2024-10-01",
+        end_date="2024-10-02",
+        interval="1m",
+    )
+
+    assert dates == {"2024-10-01", "2024-10-02"}
+    assert len(calls) == 2
+    assert calls[0]["url"] == "https://s3.ap-northeast-1.amazonaws.com/data.binance.vision/"
+    assert calls[0]["params"] == {
+        "list-type": "2",
+        "prefix": "data/futures/um/daily/klines/BTCUSDT/1m/",
+        "max-keys": "1000",
+    }
+    assert calls[1]["params"] == {
+        "list-type": "2",
+        "prefix": "data/futures/um/daily/klines/BTCUSDT/1m/",
+        "max-keys": "1000",
+        "continuation-token": "page-2",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_vision_kline_available_dates_raises_on_listing_error(monkeypatch) -> None:
+    """Vision listing should surface fetch failures as MarketDataFetchError."""
+    service = MarketDataService(AsyncMock())
+    calls: list[dict[str, object]] = []
+    responses = [_FakeAioHttpResponse(payload="boom", status=500)]
+
+    monkeypatch.setattr(
+        market_service_module.aiohttp,
+        "ClientSession",
+        lambda *args, **kwargs: _FakeAioHttpSession(list(responses), calls),
+    )
+
+    with pytest.raises(MarketDataFetchError, match="Failed to list Vision kline files for BTCUSDT"):
+        await service._get_vision_kline_available_dates(
+            symbol="BTCUSDT",
+            start_date="2024-10-01",
+            end_date="2024-10-02",
+            interval="1m",
+        )

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -6,11 +6,11 @@
 
 import asyncio
 import time
+from datetime import UTC, datetime
 from decimal import Decimal
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from binance.exceptions import BinanceAPIException
 
 from cryptoservice.models import PerpetualMarketTicker
 
@@ -80,6 +80,28 @@ def test_kline_downloader_generate_recommendations_handles_zero_symbols():
     assert downloader._generate_recommendations([], []) == ["no symbols to process"]
 
 
+def test_kline_downloader_expand_ranges_to_dates_includes_same_day_partial_gap() -> None:
+    """Same-day incremental gaps should still expand to that calendar day."""
+    from cryptoservice.services.downloaders import KlineDownloader
+
+    start_ms = int(datetime(2024, 10, 1, 12, 0, tzinfo=UTC).timestamp() * 1000)
+    end_ms = int(datetime(2024, 10, 1, 12, 30, tzinfo=UTC).timestamp() * 1000)
+
+    dates = KlineDownloader._expand_ranges_to_dates([(str(start_ms), str(end_ms))])
+    assert dates == ["2024-10-01"]
+
+
+def test_kline_downloader_expand_ranges_to_dates_keeps_end_exclusive_boundary() -> None:
+    """A full day [start, next_day_start) should produce exactly one date."""
+    from cryptoservice.services.downloaders import KlineDownloader
+
+    start_ms = int(datetime(2024, 10, 1, 0, 0, tzinfo=UTC).timestamp() * 1000)
+    end_ms = int(datetime(2024, 10, 2, 0, 0, tzinfo=UTC).timestamp() * 1000)
+
+    dates = KlineDownloader._expand_ranges_to_dates([(str(start_ms), str(end_ms))])
+    assert dates == ["2024-10-01"]
+
+
 @pytest.mark.asyncio
 async def test_kline_downloader_treats_empty_outcome_as_failed_symbol(tmp_path):
     """`empty` symbol outcome should be counted as failed for run summary."""
@@ -89,7 +111,7 @@ async def test_kline_downloader_treats_empty_outcome_as_failed_symbol(tmp_path):
     downloader = KlineDownloader(AsyncMock(), request_delay=0.0)
     downloader.db = AsyncMock()
     downloader.db.initialize = AsyncMock()
-    downloader._process_symbol = AsyncMock(  # type: ignore[method-assign]
+    downloader._process_symbol = AsyncMock(
         return_value={
             "status": "empty",
             "missing": {
@@ -113,6 +135,48 @@ async def test_kline_downloader_treats_empty_outcome_as_failed_symbol(tmp_path):
     assert report.successful_symbols == 0
     assert report.failed_symbols == ["BTCUSDT"]
     assert len(report.missing_periods) == 1
+
+
+@pytest.mark.asyncio
+async def test_kline_downloader_pages_with_futures_klines_client():
+    """Downloader paginates via futures_klines and yields validated rows."""
+    from cryptoservice.models import Freq
+    from cryptoservice.services.downloaders import KlineDownloader
+
+    mock_client = AsyncMock()
+    mock_client.futures_klines = AsyncMock(
+        return_value=[
+            [
+                1730000000000,
+                "100.0",
+                "110.0",
+                "90.0",
+                "105.0",
+                "1000.0",
+                1730000059999,
+                "105000.0",
+                42,
+                "500.0",
+                "52500.0",
+                "0",
+            ]
+        ]
+    )
+    downloader = KlineDownloader(mock_client, request_delay=0.0)
+
+    rows = [
+        row
+        async for row in downloader.download_single_symbol(
+            symbol="BTCUSDT",
+            start_ts="1730000000000",
+            end_ts="1730000100000",
+            interval=Freq.m1,
+        )
+    ]
+
+    assert len(rows) == 1
+    assert rows[0].symbol == "BTCUSDT"
+    mock_client.futures_klines.assert_awaited()
 
 
 @pytest.mark.asyncio
@@ -207,7 +271,7 @@ async def test_market_service_with_mocks():
     from cryptoservice.services import MarketDataService
 
     # Mock整个客户端工厂
-    with patch("cryptoservice.client.BinanceClientFactory.create_async_client") as mock_create:
+    with patch("cryptoservice.client.BinanceClientFactory.create_gateway") as mock_create:
         mock_client = AsyncMock()
         mock_create.return_value = mock_client
 
@@ -230,12 +294,49 @@ async def test_service_error_handling():
     """测试服务错误处理."""
     from cryptoservice.services import MarketDataService
 
-    with patch("cryptoservice.client.BinanceClientFactory.create_async_client") as mock_create:
+    with patch("cryptoservice.client.BinanceClientFactory.create_gateway") as mock_create:
         # 模拟创建客户端失败
         mock_create.side_effect = Exception("Connection failed")
 
         with pytest.raises(Exception, match="Connection failed"):
             await MarketDataService.create("invalid_key", "invalid_secret")
+
+
+@pytest.mark.asyncio
+async def test_get_perpetual_symbols_retries_on_rate_limit():
+    """Perpetual symbol fetch should retry transient Binance throttle errors."""
+    from cryptoservice.services import MarketDataService
+
+    class FakeRateLimitError(Exception):
+        status_code = 429
+        code = -1003
+
+    mock_client = AsyncMock()
+    mock_client.futures_exchange_info = AsyncMock(
+        side_effect=[
+            FakeRateLimitError("(-1003, 'Too many requests')"),
+            {
+                "symbols": [
+                    {"symbol": "BTCUSDT", "contractType": "PERPETUAL", "status": "TRADING"},
+                    {"symbol": "ETHUSD_240628", "contractType": "CURRENT_QUARTER", "status": "TRADING"},
+                ]
+            },
+        ]
+    )
+    service = MarketDataService(mock_client)
+    rate_manager = service.kline_downloader._get_async_rate_manager("fapi_exchange_info")
+
+    async def _fast_handle_rate_limit_error() -> float:
+        rate_manager.consecutive_errors += 1
+        rate_manager.cooldown_until = 0.0
+        return 0.0
+
+    rate_manager.handle_rate_limit_error = _fast_handle_rate_limit_error
+
+    symbols = await service.get_perpetual_symbols()
+
+    assert symbols == ["BTCUSDT"]
+    assert mock_client.futures_exchange_info.await_count == 2
 
 
 # ================= 下载器功能测试 =================
@@ -350,7 +451,13 @@ async def test_base_downloader_formats_binance_invalid_json_exception():
             return "<html>forbidden</html>"
 
     downloader = TestDownloader(AsyncMock())
-    error = BinanceAPIException(FakeResponse(), 403, "<html>forbidden</html>")
+    class FakeBinanceError(Exception):
+        status_code = 403
+        code = -1003
+        message = "forbidden"
+        response = FakeResponse()
+
+    error = FakeBinanceError("boom")
 
     message = downloader._format_exception_message(error)
 
@@ -490,7 +597,7 @@ async def test_base_downloader_429_triggers_adaptive_scale_down():
         manager.cooldown_until = time.time()
         return 0.0
 
-    manager.handle_rate_limit_error = fast_handle_rate_limit_error  # type: ignore[assignment]
+    manager.handle_rate_limit_error = fast_handle_rate_limit_error
 
     limiter = await downloader._get_async_limiter(endpoint_key, hard_cap=8)
     for _ in range(16):


### PR DESCRIPTION
## Summary
- switch Vision kline availability lookup to S3 list API with pagination support
- fix date-range expansion so same-day incremental gaps still produce a target Vision day
- preserve missing period details for `empty`/`failed` symbol outcomes in kline batch aggregation
- add regression tests for Vision listing pagination/error handling and same-day range expansion
- align gateway/downloader/service typing/lint compliance so hooks pass

## Validation
- `.venv/bin/python -m pytest -q` (307 passed, 1 skipped, 1 deselected)
- `.venv/bin/pre-commit run --all-files` (all hooks passed)
